### PR TITLE
Add terms of service for community template gallery

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1,3 +1,10 @@
+___TERMS_OF_SERVICE___
+
+By creating or modifying this file you agree to Google Tag Manager's Community
+Template Gallery Developer Terms of Service available at
+https://developers.google.com/tag-manager/gallery-tos (or such other URL as
+Google may provide), as modified from time to time.
+
 ___INFO___
 
 {


### PR DESCRIPTION
The previous pull request was not sufficient and we havee to agree to the terms of use.
* https://github.com/line/line-conversion-api-server-tag/pull/2
* reference: https://developers.google.com/tag-manager/templates/gallery?hl=ja#terms_of_service