### PR TITLE
Changed metadata.yaml to refer to the version that describes the Terms of Service

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
 homepage: "https://data.linebiz.com/solutions/conversion-api"
 documentation: "https://conversion-api-docs.linebiz.com"
 versions:
-  - sha: 26d48f4800dfac1aaa6aac110ed9c029f1d8a3b3
+  - sha: a38a0c7c38fe77f38cf2ae28d982362be08e5864
     changeNotes: Initial support google gallery template.


### PR DESCRIPTION
I had previously added the Terms of Service consent (#3), but the metadata.yaml was still referencing the old version, which seems to have caused the error.
* https://github.com/line/line-conversion-api-server-tag/issues/6

Therefore, changed metadata.yaml to reference the version that describes the terms of use.
