### PR TITLE
Add Support for LINE Standard Event

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,3 +3,5 @@ documentation: "https://conversion-api-docs.linebiz.com"
 versions:
   - sha: a38a0c7c38fe77f38cf2ae28d982362be08e5864
     changeNotes: Initial support google gallery template.
+  - sha: f77c8360b481ce0107664f0d448f2a369643a44c
+    changeNotes: Support LINE Standard Event.

--- a/src/template_code.js
+++ b/src/template_code.js
@@ -22,6 +22,15 @@ module.exports = (data, require) => {
   const CONTENT_TYPE_HEADER = "Content-Type";
   const CONTENT_TYPE_APPLICATION_JSON = "application/json";
   const HASHED_REGEX_PATTERN = "^[0-9a-fA-F]{64}$";
+  const LINE_STANDARD_EVENTS = [
+    "ViewItemDetail",
+    "AddToCart",
+    "InitiateCheckOut",
+    "Purchase",
+    "GenerateLead",
+    "CompleteReservation",
+    "CompleteRegistration",
+  ];
 
   // HTTP Header Definitions
   const CONVERSION_API_ACCESS_TOKEN_HEADER = "X-Line-TagAccessToken";
@@ -106,6 +115,13 @@ module.exports = (data, require) => {
   requestBody.web.ip_address = ipAddress;
   requestBody.web.user_agent = userAgent;
 
+  // Custom Object (For standard event).
+  if (isStandardEvent(eventName)) {
+    requestBody.custom = {};
+    requestBody.custom.value = eventData["x-line-event-value"];
+    requestBody.custom.currency = eventData["x-line-event-currency"];
+  }
+
   // Send settings
   const endpoint = LINE_CONVERSION_API_ENDPOINT + "/" + lineTagId + "/events";
   const options = {};
@@ -186,6 +202,15 @@ module.exports = (data, require) => {
 
   function isInternalError(statusCode) {
     return statusCode >= 500 && statusCode < 600;
+  }
+
+  function isStandardEvent(eventName) {
+    for (let i = 0; i < LINE_STANDARD_EVENTS.length; ++i) {
+      if (LINE_STANDARD_EVENTS[i] === eventName) {
+        return true;
+      }
+    }
+    return false;
   }
 
   function getEventName() {


### PR DESCRIPTION
# Summary

LINE Ads began to support the Standard Event.
Therefore, this tag template should also support it.

There are some optional parameters for the Standard Event, but for now, the `value`, and `currency` parameter needs to be supported.
(The' value' parameter is mandatory if you want to send the Purchase event using a server-side tag container. The `currency` is recommended.)

For more detail about the Standard Event in LINE Ads, please take a look at the following documentation.

* [LINE for Business - 標準イベントを利用する](https://www.linebiz.com/jp/manual/line-ads/tracking_021/)
* https://conversion-api-docs.linebiz.com/en/#tag/LINE-Conversion-API-v1/operation/postback
![image](https://github.com/line/line-conversion-api-server-tag/assets/48251504/30800817-e94f-4863-8c6c-f8ae96fd7409)

After this PR is merged, I'll update how to use the parameters for this template.
* `x-line-event-value`
* `x-line-event-currency`