### PR TITLE
Support Test Flag for LINE Conversion API

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -5,3 +5,5 @@ versions:
     changeNotes: Initial support google gallery template.
   - sha: f77c8360b481ce0107664f0d448f2a369643a44c
     changeNotes: Support LINE Standard Event.
+  - sha: 99143fdc32a56ecbcf5c5e2bbd15c76563f37aff
+    changeNotes: Support LINE Conversion API test flag.

--- a/src/template_code.js
+++ b/src/template_code.js
@@ -60,6 +60,7 @@ module.exports = (data, require) => {
   const accessToken = data.lineAccessToken;
   const channelId = data.lineChannelId;
   const enableCookie = data.enableCookie;
+  const testFlag = data.testFlag;
   const url = eventData.page_location;
   const lineClickId = url ? getLineClickId(parseUrl(url)) : undefined;
   const browserId =
@@ -96,6 +97,7 @@ module.exports = (data, require) => {
     eventType === "conversion" ? eventName : undefined;
   requestBody.event.deduplication_key = dedupe;
   requestBody.event.event_timestamp = timestampSec;
+  requestBody.event.test_flag = testFlag;
 
   // User Object
   requestBody.user = {};

--- a/template.tpl
+++ b/template.tpl
@@ -127,6 +127,13 @@ ___TEMPLATE_PARAMETERS___
     "checkboxText": "Enable measurement using cookies",
     "simpleValueType": true,
     "help": "Please enable this checkbox if you want to read/update the first-party cookie `__lt__cid` for measurement with the LINE Tag. This enables server side tag to measure conversions with the first-party cookie in the Conversion API."
+  },
+  {
+    "type": "CHECKBOX",
+    "name": "testFlag",
+    "checkboxText": "Enable testing Conversion API Event",
+    "simpleValueType": true,
+    "help": "Please enable this checkbox if you want to enable testing Conversion API Event. Events sent with this flag enabled will not be used for accumulation to audiences/reporting/ad delivery optimization and will only be used for testing purposes."
   }
 ]
 
@@ -195,6 +202,7 @@ const lineTagId = data.lineTagId;
 const accessToken = data.lineAccessToken;
 const channelId = data.lineChannelId;
 const enableCookie = data.enableCookie;
+const testFlag = data.testFlag;
 const url = eventData.page_location;
 const lineClickId = url ? getLineClickId(parseUrl(url)) : undefined;
 const browserId =
@@ -231,6 +239,7 @@ requestBody.event.event_name =
   eventType === "conversion" ? eventName : undefined;
 requestBody.event.deduplication_key = dedupe;
 requestBody.event.event_timestamp = timestampSec;
+requestBody.event.test_flag = testFlag;
 
 // User Object
 requestBody.user = {};

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -128,6 +128,7 @@ describe("test", () => {
         lineAccessToken: "dummyAccessToken",
         lineChannelId: "dummyChannelId",
         enableCookie: true,
+        testFlag: false,
         gtmOnSuccess: () => {
           successAssertion.call();
         },
@@ -176,6 +177,7 @@ describe("test", () => {
               Date.now() / 1000,
               10
             );
+            expect(requests[0].event.test_flag).to.be.false;
 
             expect(requests[0].user.click_id).to.be.undefined;
             expect(requests[0].user.browser_id).to.be.matches(
@@ -229,6 +231,7 @@ describe("test", () => {
         lineAccessToken: "dummyAccessToken",
         lineChannelId: undefined,
         enableCookie: true,
+        testFlag: false,
         gtmOnSuccess: () => {
           successAssertion.call();
         },
@@ -302,6 +305,7 @@ describe("test", () => {
         lineAccessToken: "dummyAccessToken",
         lineChannelId: undefined,
         enableCookie: true,
+        testFlag: false,
         gtmOnSuccess: () => {
           successAssertion.call();
         },
@@ -374,6 +378,7 @@ describe("test", () => {
         lineAccessToken: "dummyAccessToken",
         lineChannelId: undefined,
         enableCookie: true,
+        testFlag: false,
         gtmOnSuccess: () => {
           successAssertion.call();
         },
@@ -426,6 +431,7 @@ describe("test", () => {
         lineAccessToken: "dummyAccessToken",
         lineChannelId: undefined,
         enableCookie: true,
+        testFlag: false,
         gtmOnSuccess: () => {
           successAssertion.call();
         },
@@ -481,6 +487,7 @@ describe("test", () => {
         lineAccessToken: "dummyAccessToken",
         lineChannelId: undefined,
         enableCookie: true,
+        testFlag: false,
         gtmOnSuccess: () => {
           successAssertion.call();
         },
@@ -519,6 +526,7 @@ describe("test", () => {
         lineAccessToken: "dummyAccessToken",
         lineChannelId: undefined,
         enableCookie: true,
+        testFlag: false,
         gtmOnSuccess: () => {
           successAssertion.call();
         },
@@ -570,6 +578,7 @@ describe("test", () => {
         lineAccessToken: "dummyAccessToken",
         lineChannelId: undefined,
         enableCookie: false,
+        testFlag: false,
         gtmOnSuccess: () => {
           successAssertion.call();
         },
@@ -603,6 +612,7 @@ describe("test", () => {
         lineAccessToken: "dummyAccessToken",
         lineChannelId: undefined,
         enableCookie: true,
+        testFlag: false,
         gtmOnSuccess: () => {
           successAssertion.call();
         },
@@ -640,6 +650,7 @@ describe("test", () => {
         lineAccessToken: "dummyAccessToken",
         lineChannelId: undefined,
         enableCookie: true,
+        testFlag: false,
         gtmOnSuccess: () => {
           successAssertion.call();
         },
@@ -694,5 +705,64 @@ describe("test", () => {
 
     successAssertion.once();
     failureAssertion.never();
+  });
+
+  it("should succeed that test_flag is set to true", async () => {
+    const successAssertion = getCallAssertion();
+    const failureAssertion = getCallAssertion();
+    const cookieBakeAssertion = getCallAssertion();
+    await template(
+      {
+        event: "conversion",
+        lineTagId: "00000000-0000-0000-0000-000000000000",
+        eventName: undefined,
+        lineAccessToken: "dummyAccessToken",
+        lineChannelId: undefined,
+        enableCookie: true,
+        testFlag: true,
+        gtmOnSuccess: () => {
+          successAssertion.call();
+        },
+        gtmOnFailure: () => {
+          failureAssertion.call();
+        },
+      },
+      (packageName) => {
+        if (packageName === "sendHttpRequest") {
+          return (url, options, postBody) => {
+            expect(postBody).not.to.be.null;
+            const requests = JSON.parse(postBody);
+
+            expect(url).to.be.eq(
+              "https://conversion-api.tr.line.me/v1/00000000-0000-0000-0000-000000000000/events"
+            );
+
+            expect(options.method).to.be.eq("POST");
+            expect(options.headers["X-Line-TagAccessToken"]).to.be.eq(
+              "dummyAccessToken"
+            );
+
+            expect(requests).length(1);
+            expect(requests[0].event.source_type).to.be.eq("web");
+            expect(requests[0].event.event_type).to.be.eq("conversion");
+            expect(requests[0].event.event_name).to.be.eq("Conversion");
+            expect(requests[0].event.test_flag).to.be.true;
+
+            return new Promise((resolve) => {
+              resolve({
+                statusCode: 202,
+                body: undefined,
+                headers: [],
+              });
+            });
+          };
+        }
+        return requireFunctionBase[packageName];
+      }
+    );
+
+    successAssertion.once();
+    failureAssertion.never();
+    cookieBakeAssertion.never();
   });
 });


### PR DESCRIPTION
The newly supported test_flag sending is also supported in server side templates.

* https://conversion-api-docs.linebiz.com/en/#tag/LINE-Conversion-API-v1/operation/postback
![image](https://github.com/line/line-conversion-api-server-tag/assets/48251504/86cf5ea1-2637-478a-bff2-00c779269eb5)

If test_flag is not enabled, it will be sent with test_flag = false.

![スクリーンショット 2023-09-22 15 33 57](https://github.com/line/line-conversion-api-server-tag/assets/48251504/e8c03c37-4901-4a24-b87f-ab22f035c456)

On the other hand, if test_flag is enabled, it will be sent with test_flag = true.

![image](https://github.com/line/line-conversion-api-server-tag/assets/48251504/3dad4436-393f-422d-b5f5-857e3634eb13)
![スクリーンショット 2023-09-22 15 20 39](https://github.com/line/line-conversion-api-server-tag/assets/48251504/10fc93ef-39c3-4999-88a8-86fe29246c56)