### PR TITLE
Change the sort order of versions in metadata.yml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,9 +1,9 @@
 homepage: "https://data.linebiz.com/solutions/conversion-api"
 documentation: "https://conversion-api-docs.linebiz.com"
 versions:
-  - sha: a38a0c7c38fe77f38cf2ae28d982362be08e5864
-    changeNotes: Initial support google gallery template.
-  - sha: f77c8360b481ce0107664f0d448f2a369643a44c
-    changeNotes: Support LINE Standard Event.
   - sha: 99143fdc32a56ecbcf5c5e2bbd15c76563f37aff
     changeNotes: Support LINE Conversion API test flag.
+  - sha: f77c8360b481ce0107664f0d448f2a369643a44c
+    changeNotes: Support LINE Standard Event.
+  - sha: a38a0c7c38fe77f38cf2ae28d982362be08e5864
+    changeNotes: Initial support google gallery template.


### PR DESCRIPTION
According to the document provided by Google, we need to change the order of the versions in the metadata.yml. (in descending order)

https://developers.google.com/tag-platform/tag-manager/templates/gallery?hl=ja#update_your_template
![image](https://github.com/user-attachments/assets/7fe0bf31-5581-4ca9-9e69-fb869f01b3a5)
